### PR TITLE
Update job titles for clarity in English and Japanese

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -36,8 +36,8 @@
   "workHistory": {
     "responsibilities": "Responsibilities",
     "projects": "Projects",
-    "mainJob": "Full-time",
-    "sideProject": "Side Projects"
+    "mainJob": "Full-time Employee",
+    "sideProject": "Contract Work"
   },
   "project": {
     "responsibilities": "Responsibilities",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -36,8 +36,8 @@
   "workHistory": {
     "responsibilities": "職務内容",
     "projects": "プロジェクト事例",
-    "mainJob": "本業",
-    "sideProject": "副業"
+    "mainJob": "正社員",
+    "sideProject": "業務委託"
   },
   "project": {
     "responsibilities": "担当業務",


### PR DESCRIPTION
Clarify job titles in the work history section for both English and Japanese translations.